### PR TITLE
percentCompleted is NaN as the result of a division by zero

### DIFF
--- a/SwiftRacer/SwiftRace/Race.swift
+++ b/SwiftRacer/SwiftRace/Race.swift
@@ -14,7 +14,7 @@ struct RaceData {
     
     func stickerImage(percentCompleted: CGFloat) -> UIImage? {
         let raceProgressView = RaceProgressView(frame: CGRect(origin: .zero, size: CGSize(width: 300, height: 35)))
-        raceProgressView.percentCompleted = percentCompleted
+        raceProgressView.percentCompleted = percentCompleted.isNaN ? 0 : percentCompleted
         return UIImage(view: raceProgressView)
     }
 }


### PR DESCRIPTION
if distance is 0 in healthKit the operation to calculate the percentage completed is crashing because of a division by 0

resolve #1 